### PR TITLE
Add alembic revision with predefined views

### DIFF
--- a/migrations/versions/0_1.py
+++ b/migrations/versions/0_1.py
@@ -1,4 +1,4 @@
-"""Database schema migration for schema version 0.1."""
+"""Alembic schema migration for database schema version 0.1."""
 
 import sqlalchemy as sa
 from alembic import op
@@ -11,7 +11,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    """Upgrade from previous database versions to the current revision"""
+    """Upgrade the database to this schema version"""
 
     op.create_table(
         'log_data',
@@ -29,6 +29,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Downgrade from the current database versions to the previous revision"""
+    """Undo changes implemented when upgrading to this schema version"""
 
-    raise RuntimeError('There is no database revision below version 0.1.')
+    op.execute("DROP TABLE log_data;")

--- a/migrations/versions/0_1_views.py
+++ b/migrations/versions/0_1_views.py
@@ -1,0 +1,47 @@
+"""Alembic schema migration for database schema version 0.1 with custom views enabled."""
+
+from alembic import op
+
+# Revision identifiers used by Alembic
+revision = '0.1.views'
+down_revision = None
+depends_on = '0.1'
+
+
+def upgrade() -> None:
+    """Upgrade the database to this schema version"""
+
+    op.execute("""
+        CREATE VIEW package_count AS
+            SELECT
+                package,
+                COUNT(*) AS total,
+                time AS lastload
+            FROM
+                log_data
+            GROUP BY
+                package
+            ORDER BY package DESC;
+    """)
+
+    op.execute("""
+        CREATE VIEW package_version_count AS
+            SELECT
+                package,
+                version,
+                COUNT(*) AS total,
+                time AS lastload
+            FROM
+                log_data
+            GROUP BY
+                package,
+                version
+            ORDER BY package, version DESC;
+    """)
+
+
+def downgrade() -> None:
+    """Undo changes implemented when upgrading to this schema version"""
+
+    op.execute("DROP VIEW package_count;")
+    op.execute("DROP VIEW package_version_count;")


### PR DESCRIPTION
Adds the `0.1.views` revision which extends schema version `0.1` with predefined views.