### PR TITLE
Migrate application to Postrges instead of MariaDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Environment files
-.env
+.ingest.env
 
 # Cache files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![](https://app.codacy.com/project/badge/Grade/da5fd23a62874c989f9b80ba201af924)](https://app.codacy.com/gh/pitt-crc/lmod_tracking/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 Lmod provides [official support](https://lmod.readthedocs.io/en/latest/300_tracking_module_usage.html) for tracking module usage via the system log.
-This repository provides scripts and utilities for ingesting the resulting log data into a MySQL database.
+This repository provides scripts and utilities for ingesting the resulting log data into a Postgres database.
 
 ## Setup Instructions
 
 These instructions assume the following conditions are already met:
 
 - Lmod logging is configured and running on your cluster.
-- A MySQL server is installed and configured with valid user credentials.
+- A Postgres server is installed and configured with valid user credentials.
 
 In the sections below you will:
 
@@ -38,18 +38,18 @@ If your format differs from the above, you must change it by editing the `SitePa
 ### Database Connection Settings
 
 Database connection settings are configured as environmental variables.
-For convenience, these values can be defined in a `.env` file.
+For convenience, these values can be defined in a `.ingest.env` file under the user's home directory.
 A list of accepted variables and their defaults is provided in the table below.
 
-| Variable  | Default     | Description                              |
-|-----------|-------------|------------------------------------------|
-| `DB_USER` |             | User name for logging into the database. |
-| `DB_PASS` |             | Password for logging into the database.  |
-| `DB_HOST` | `localhost` | Host running the MySQL database.         |
-| `DB_PORT` | `3306`      | Port for accessing the MySQL database.   |
-| `DB_NAME` |             | Name of the database to write to.        |
+| Variable  | Default     | Description                               |
+|-----------|-------------|-------------------------------------------|
+| `DB_USER` |             | User name for logging into the database.  |
+| `DB_PASS` |             | Password for logging into the database.   |
+| `DB_HOST` | `localhost` | Host running the Postgres database.       |
+| `DB_PORT` | `3306`      | Port for accessing the Postgres database. |
+| `DB_NAME` |             | Name of the database to write to.         |
 
-The following example demonstrates a minimally valid `.env` file:
+The following example demonstrates a minimally valid `.ingest.env` file:
 
 ```bash
 DB_USER=lmod_ingest
@@ -69,7 +69,7 @@ lmod-ingest --help
 ```
 
 Once installed, the necessary database schema can be applied using the `migrate` command.
-Before running the command, make sure you have already created a `.env` file as described in the previous step.
+Before running the command, make sure you have already created a `.ingest.env` file as described in the previous step.
 The `--sql` option can be used to perform an initial dry run and print the migration SQL logic without modifying the database.
 
 ```bash

--- a/lmod_ingest/main.py
+++ b/lmod_ingest/main.py
@@ -6,10 +6,10 @@ Usage:
   lmod_ingest --version
 
 Options:
-  -h --help  Show this help text
-  <path>     Path of the log data to ingest
-  --sql      Print migration SQL but do not execute it
-  --version  Show the application version number
+  -h --help     Show this help text
+  <path>        Path of the log data to ingest
+  --sql         Print migration SQL but do not execute it
+  --version     Show the application version number
 """
 
 import logging
@@ -42,9 +42,10 @@ def ingest(path: Path) -> None:
     """Ingest data from a log file into the application database
 
     Args:
-        path: Path of the lg file
+        path: Path of the log file
     """
 
+    logging.info(f'Ingesting {path.resolve()}')
     db_engine = sa.engine.create_engine(url=fetch_db_url())
     with db_engine.connect() as connection:
         data = parse_log_data(path)
@@ -78,4 +79,4 @@ def main():
             migrate(arguments['--sql'])
 
     except Exception as caught:
-        logging.error(str(caught))
+        logging.error(caught)

--- a/lmod_ingest/main.py
+++ b/lmod_ingest/main.py
@@ -27,7 +27,7 @@ from . import __version__
 from .utils import fetch_db_url, ingest_data_to_db, parse_log_data
 
 # Load environmental variables
-load_dotenv()
+load_dotenv(Path.home() / '.ingest.env')
 
 # Database metadata
 MIGRATIONS_DIR = Path(__file__).resolve().parent / 'migrations'

--- a/lmod_ingest/migrations/env.py
+++ b/lmod_ingest/migrations/env.py
@@ -7,7 +7,7 @@ from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
-# this is the Alembic Config object, which provides
+# This is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
 
@@ -37,16 +37,19 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection: Connection) -> None:
-    context.configure(connection=connection, target_metadata=None)
+    """Synchronous helper function for executing database migrations
 
+    Args:
+        connection: An open database connection
+    """
+
+    context.configure(connection=connection, target_metadata=None)
     with context.begin_transaction():
         context.run_migrations()
 
 
 async def run_async_migrations() -> None:
-    """In this scenario we need to create an Engine
-    and associate a connection with the context.
-    """
+    """Connect to the database and execute the schema migration"""
 
     connectable = async_engine_from_config(
         config.get_section(config.config_ini_section, {}),

--- a/lmod_ingest/migrations/env.py
+++ b/lmod_ingest/migrations/env.py
@@ -1,7 +1,11 @@
 """Environment configuration file and entrypoint for the ``alembic`` utility."""
 
+import asyncio
+
 from alembic import context
-from sqlalchemy import pool, engine_from_config
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -32,23 +36,34 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
-def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=None)
 
-    In this scenario we need to create an Engine
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """In this scenario we need to create an Engine
     and associate a connection with the context.
     """
 
-    connectable = engine_from_config(
+    connectable = async_engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
 
-    with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=None)
-        with context.begin_transaction():
-            context.run_migrations()
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    asyncio.run(run_async_migrations())
 
 
 if context.is_offline_mode():

--- a/lmod_ingest/migrations/versions/0_1.py
+++ b/lmod_ingest/migrations/versions/0_1.py
@@ -2,7 +2,7 @@
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects.mysql import DATETIME
+from sqlalchemy.dialects.mysql import TIMESTAMP
 
 # Revision identifiers used by Alembic
 revision = '0.1'
@@ -17,7 +17,7 @@ def upgrade() -> None:
         'log_data',
         sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column('logname', sa.String(4096), nullable=False),
-        sa.Column('time', DATETIME(fsp=6), nullable=False),
+        sa.Column('time', TIMESTAMP(fsp=6), nullable=False),
         sa.Column('host', sa.String(255), nullable=False),
         sa.Column('user', sa.String(50), nullable=False),
         sa.Column('module', sa.String(100), nullable=False),
@@ -32,7 +32,7 @@ def upgrade() -> None:
             SELECT
                 package,
                 COUNT(*) AS total,
-                time AS lastload
+                max(time) AS lastload
             FROM
                 log_data
             GROUP BY
@@ -46,7 +46,7 @@ def upgrade() -> None:
                 package,
                 version,
                 COUNT(*) AS total,
-                time AS lastload
+                max(time) AS lastload
             FROM
                 log_data
             GROUP BY

--- a/lmod_ingest/utils.py
+++ b/lmod_ingest/utils.py
@@ -2,12 +2,12 @@
 
 import logging
 import os
-import time
 from pathlib import Path
 
+import math
 import pandas as pd
 import sqlalchemy as sa
-from sqlalchemy.dialects.mysql import insert
+from sqlalchemy.dialects.postgresql import insert
 
 
 def fetch_db_url() -> str:
@@ -25,13 +25,13 @@ def fetch_db_url() -> str:
     db_user = os.getenv('DB_USER')
     db_password = os.getenv('DB_PASS')
     db_host = os.getenv('DB_HOST', default='localhost')
-    db_port = os.getenv('DB_PORT', default=3306)
+    db_port = os.getenv('DB_PORT', default=5432)
     db_name = os.getenv('DB_NAME')
 
     if not (db_user and db_password and db_name):
-        raise ValueError('One or more environmental variables are not properly configured')
+        raise ValueError('DB_NAME, DB_USER, and DB_PASS must be configured as environmental variables')
 
-    return f'mysql+mysqlconnector://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}'
+    return f'postgresql+asyncpg://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}'
 
 
 def parse_log_data(path: Path) -> pd.DataFrame:
@@ -47,8 +47,6 @@ def parse_log_data(path: Path) -> pd.DataFrame:
         A DataFrame with the parsed data
     """
 
-    logging.info(f'Parsing log data')
-
     # Expect columns to be separated by whitespace and use ``=`` as a secondary
     # delimiter to automatically split up strings like "user=admin123" into two columns
     log_data = pd.read_table(
@@ -61,7 +59,7 @@ def parse_log_data(path: Path) -> pd.DataFrame:
     )
 
     # Convert UTC decimals to a MySQL compatible string format
-    log_data['time'] = pd.to_datetime(log_data['time'], unit='s').dt.strftime('%Y-%m-%d %H:%M:%S.%f')
+    log_data['time'] = pd.to_datetime(log_data['time'], unit='s')
 
     # Split the module name into package names and versions
     log_data[['package', 'version']] = log_data.module.str.split('/', n=1, expand=True)
@@ -70,7 +68,7 @@ def parse_log_data(path: Path) -> pd.DataFrame:
     return log_data.dropna(subset=['user'])
 
 
-def ingest_data_to_db(data: pd.DataFrame, name: str, connection: sa.Connection) -> None:
+async def ingest_data_to_db(data: pd.DataFrame, name: str, connection) -> None:
     """Ingest data into a database
 
     The ``data`` argument is expected to follow the same data model as the
@@ -82,16 +80,16 @@ def ingest_data_to_db(data: pd.DataFrame, name: str, connection: sa.Connection) 
         connection: An open database connection
     """
 
-    # Dynamically determine the table schema
-    table = sa.Table(name, sa.MetaData(), autoload_with=connection.engine)
+    metadata = sa.MetaData()
+    await connection.run_sync(metadata.reflect, only=[name])
+    table = sa.Table(name, metadata, autoload_with=connection)
 
-    logging.info(f'Ingesting data into database table {connection.engine.url.database}.{table.name}')
-    start = time.time()
+    chunk_size = 32000 // len(data.columns)
+    for i in range(0, len(data), chunk_size):
+        chunk = data.iloc[i:i + chunk_size]
 
-    # Implicitly assume the `data` argument uses the same data model as the database table
-    insert_stmt = insert(table).values(data.to_dict(orient="records"))
-    on_duplicate_key_stmt = insert_stmt.on_duplicate_key_update(insert_stmt.inserted)
-    connection.execute(on_duplicate_key_stmt)
-    connection.commit()
-
-    logging.info(f'Ingested {len(data)} log entries in {time.time() - start:.2f} seconds')
+        # Implicitly assume the `data` argument uses the same data model as the database table
+        insert_stmt = insert(table).values(chunk.to_dict(orient="records"))
+        on_duplicate_key_stmt = insert_stmt.on_conflict_do_nothing()
+        await connection.execute(on_duplicate_key_stmt)
+        await connection.commit()

--- a/lmod_ingest/utils.py
+++ b/lmod_ingest/utils.py
@@ -30,7 +30,7 @@ def fetch_db_url() -> str:
     if not (db_user and db_password and db_name):
         raise ValueError('DB_NAME, DB_USER, and DB_PASS must be configured as environmental variables')
 
-    return f'postgresql+asyncpg://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}'
+    return f'postgresql+asyncpg://{db_user}:{db_password}@/{db_name}?host={db_host}&port={db_port}'
 
 
 def parse_log_data(path: Path) -> pd.DataFrame:

--- a/lmod_ingest/utils.py
+++ b/lmod_ingest/utils.py
@@ -4,7 +4,6 @@ import logging
 import os
 from pathlib import Path
 
-import math
 import pandas as pd
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import insert

--- a/lmod_ingest/utils.py
+++ b/lmod_ingest/utils.py
@@ -14,7 +14,7 @@ def fetch_db_url() -> str:
     """Fetch DB connection settings from environment variables
 
     Returns:
-        A sqlalchemy compatible database URL
+        A SQLAlchemy compatible database URL
 
     Raises:
         RuntimeError: If the username or password is not defined in the environment
@@ -37,7 +37,7 @@ def fetch_db_url() -> str:
 def parse_log_data(path: Path) -> pd.DataFrame:
     """Parse, format, and return data from an Lmod log file
 
-    The returned dataframe is formatted using the same data model assumed
+    The returned DataFrame is formatted using the same data model assumed
     by the ingestion database.
 
     Args:
@@ -49,7 +49,7 @@ def parse_log_data(path: Path) -> pd.DataFrame:
 
     logging.info(f'Parsing log data')
 
-    # Expect columns to be seperated by whitespace and use ``=`` as a secondary
+    # Expect columns to be separated by whitespace and use ``=`` as a secondary
     # delimiter to automatically split up strings like "user=admin123" into two columns
     log_data = pd.read_table(
         path,
@@ -60,7 +60,7 @@ def parse_log_data(path: Path) -> pd.DataFrame:
         engine='python'
     )
 
-    # Convert UTC decimals to a MYSql compatible string format
+    # Convert UTC decimals to a MySQL compatible string format
     log_data['time'] = pd.to_datetime(log_data['time'], unit='s').dt.strftime('%Y-%m-%d %H:%M:%S.%f')
 
     # Split the module name into package names and versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 alembic = "1.11.1"
+asyncpg = "0.27.0"
 docopt = "0.6.2"
 mysql-connector-python = "8.0.33"
 pandas = "2.0.2"


### PR DESCRIPTION
Closes #26 

After some investigation by @buttermutter and @iamtroy412, it turns out the MySQL driver is using a query construction algorithm that does not scale well to large insert statements. Essentially, the driver creates a template string for the query and substitutes in the column names and values. The driver's implementation uses a significant (gigabytes) amount of memory and takes multiple hours to construct insert statements for larger log files (55M file with 316,715 records).

The `asyncpg` driver for Postgres is significantly faster and  only takes <1.5 minutes for the same data mentioned above.

