### PR TITLE
Run tests before publishing package in CI

### DIFF
--- a/.github/workflows/PackagePublish.yml
+++ b/.github/workflows/PackagePublish.yml
@@ -10,8 +10,14 @@ permissions:
   id-token: write
 
 jobs:
+  run-tests:
+    name: Tests
+    uses: ./.github/workflows/PackageTest.yml
+    secrets: inherit
+
   publish-package:
     name: Publish Distribution
+    needs: run-tests
     runs-on: ubuntu-latest
     environment: ${{ matrix.environment }}
 


### PR DESCRIPTION
Updates the publication workflow to require passing tests before publishing the package.