### PR TITLE
Fix bug where application migrates to schema 0.1 instead of 0.2

### DIFF
--- a/lmod_ingest/main.py
+++ b/lmod_ingest/main.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 from . import utils, __version__
 
 # Database metadata
-CURRENT_SCHEMA_VERSION = '0.1'
+CURRENT_SCHEMA_VERSION = '0.2'
 MIGRATIONS_DIR = Path(__file__).resolve().parent / 'migrations'
 
 


### PR DESCRIPTION
Looks like I forgot to update the DB schema version number in `main.py` during the last release.