### PR TITLE
Updates docks and adds formal package level docstring

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation and Setup
 
-The `lmod-ingest` utility is installed in four steps:  
+The `lmod-ingest` utility is installed in four steps:
 
 1. Ensure your system satisfies the preliminary system requirements.
 2. Pip install the `lmod-ingest` utility.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,21 +1,12 @@
 # Installation and Setup
 
-The `lmod-ingest` utility is installed in four steps:
-
-1. Ensure your system satisfies the preliminary system requirements.
-2. Pip install the `lmod-ingest` utility.
-3. Configure the database connection settings.
-4. Migrate the database schema and run the `lmod-ingest` command-line utility.
-
-## System Prerequisites
-
-These instructions assume the following conditions are already met:
+Before installing the `lmod-ingest` utility, the following resources should already be configured in your environment:
 
 - Lmod logging is configured and running on your cluster.
 - Lmod system logs are proper configured for compatibility with the ingestion utility.
 - A Postgres server is installed and configured with valid user credentials.
 
-For more information on implementing accepted log formats, see the [log formatting guide](log_formatting.md).
+For more information on implementing accepted Lmod log formats, see the [log formatting guide](log_formatting.md).
 
 ## Package Installation
 
@@ -34,10 +25,10 @@ lmod-ingest --version
 ## Database Settings
 
 Database connection settings are configured using environmental variables.
-For convenience, these values can alternatively be defined in a `.ingest.env` file under the user's home directory.
+For convenience, these values can also be defined in a `.ingest.env` file under the user's home directory.
 Values defined in a `.ingest.env` file will always take precedence over existing environmental variables.
 
-A list of accepted variables and their defaults is provided in the table below.
+A list of application settings and their defaults is provided in the table below.
 
 | Variable  | Default     | Description                               |
 |-----------|-------------|-------------------------------------------|
@@ -48,7 +39,7 @@ A list of accepted variables and their defaults is provided in the table below.
 | `DB_NAME` |             | Name of the database to write to.         |
 
 The following example demonstrates a minimally valid `.ingest.env` file.
-**Always** choose a secure database password when operating in a production environment.
+Administrators are reminded to **always** choose a secure database password when operating in a production environment.
 
 ```bash
 DB_USER=lmod_ingest

--- a/docs/log_formatting.md
+++ b/docs/log_formatting.md
@@ -9,16 +9,16 @@ Log entries **must** follow this format to be parsable by the `lmod-ingest` appl
 
 Individual field values are defined as follows:
 
-| Field           | Description                                                          |
-|-----------------|----------------------------------------------------------------------|
-| `SYSLOG PREFIX` | A system specific message prefix added by syslog.                    |
-| `USERNAME`      | The name of the user who loaded the module.                          |
-| `JOBID`         | The nullable (`nil`) ID of the slurm job the module was loaded from. |
-| `PACKAGE`       | The name of the package loaded via lmod.                             |
-| `VERSION`       | The version of the pacakge loaded via lmod.                          |
-| `MODULEPATH`    | The path of the loaded module file.                                  |
-| `HOSTNAME`      | The machine hostname where the module was loaded.                    |
-| `UTC`           | The UTC time the module was loaded.                                  |
+| Field           | Description                                                              |
+|-----------------|--------------------------------------------------------------------------|
+| `SYSLOG PREFIX` | A system specific message prefix added by syslog. This value is ignored. |
+| `USERNAME`      | The name of the user who loaded the module.                              |
+| `JOBID`         | The nullable (`nil`) ID of the slurm job the module was loaded from.     |
+| `PACKAGE`       | The name of the package loaded via lmod.                                 |
+| `VERSION`       | The version of the pacakge loaded via lmod.                              |
+| `MODULEPATH`    | The path of the loaded module file.                                      |
+| `HOSTNAME`      | The machine hostname where the module was loaded.                        |
+| `UTC`           | The UTC time the module was loaded.                                      |
 
 ## Setting the Log Format
 

--- a/docs/source_docs/main.md
+++ b/docs/source_docs/main.md
@@ -1,3 +1,0 @@
-# lmod_ingest.main
-
-::: lmod_ingest.main

--- a/docs/source_docs/utils.md
+++ b/docs/source_docs/utils.md
@@ -1,3 +1,0 @@
-# lmod_ingest.utils
-
-::: lmod_ingest.utils

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,5 @@
 # Usage Examples
 
-The `lmod-ingest` utility is designed to provide a minimal command line interface.
 Common use cases and examples are provided in the sections below.
 
 ## Database Migration

--- a/lmod_ingest/__init__.py
+++ b/lmod_ingest/__init__.py
@@ -1,4 +1,13 @@
-"""A simple command line tool for ingesting Lmod log data into a PostgreSQL database."""
+"""
+A simple command line tool for ingesting Lmod log data into a PostgreSQL database.
+
+[Lmod](https://lmod.readthedocs.io/en/latest/index.html) is a popular
+utility for managing user runtime environments on supercomputing clusters.
+To better understand system usage patterns, many system administrators
+leverage Lmod logs to track what software is being loaded by users and where.
+The `lmod-ingest` utility is a simple ETL tool used to ingest Lmod log
+records into a Postgres database in a useful format.
+"""
 
 import importlib.metadata
 import logging

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,9 +9,6 @@ plugins:
   - search:
   - mkdocstrings:
       custom_templates: templates
-extra:
-  version:
-    provider: mike
 nav:
   - index.md
   - installation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,4 @@ nav:
   - installation.md
   - usage.md
   - log_formatting.md
-  - Source Documentation:
-      - source_docs/main.md
-      - source_docs/utils.md
 copyright: Copyright &copy; University of Pittsburgh. All rights reserved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,5 @@ coverage = "*"
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-mike = "1.1.2"
 mkdocs = "^1.5.3"
 mkdocstrings = {extras = ["python"], version = "^0.23.0"}


### PR DESCRIPTION
The package level docstring was a bit too sparse to be useful. This PR updates the docstring (which is also used to populated the documentation landing page) and adds a few other documentation improvements.